### PR TITLE
Make the SPHEREx container image name lower case

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,12 +32,12 @@ jobs:
           context: ./  # use currently-checked out files
           file: ./Dockerfile
           push: true
-          tags: localhost:5000/${{ github.repository_owner }}/spherex-tex:latest
+          tags: localhost:5000/spherex/spherex-tex:latest
 
       - name: Run tests
         working-directory: ./
         run: |
-          docker run --rm -v `pwd`:/workspace -w /workspace localhost:5000/${{ github.repository_owner }}/spherex-tex:latest sh -c 'cd test && ./test.sh'
+          docker run --rm -v `pwd`:/workspace -w /workspace localhost:5000/spherex/spherex-tex:latest sh -c 'cd test && ./test.sh'
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,4 +34,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/spherex-tex:latest
+            ghcr.io/spherex/spherex-tex:latest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 **SPHEREx TeX document resources and Docker environment.**
 
+## Docker
+
+To compile a document using the Docker image and the default SPHEREx Makefiles:
+
+```sh
+docker run -v `pwd`:/workspace -w /workspace ghcr.io/spherex/spherex-tex:latest sh -c 'make'
+```
+
 ## spherex class reference
 
 `spherex-tex` provides a custom class, named `spherex`, for formatting TeX documents. This section describes the commands and options that are provided by the `spherex` class.


### PR DESCRIPTION
Previously when building the Docker container image name we used the GitHub organization name available in the GitHub Actions context. However, it turns out that the container image tag can't contain uppercase characters (SPHEREx). This change hard-codes the docker image tag to be `ghcr.io/spherex/spherex-tex:latest`.

I'm not entirely sure if this lowercase name will authenticate correctly with GitHub Container Registry; merging this PR will tell us.