### PR TITLE
Disable git safe directory checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ FROM base AS runtime
 # Create a directory for the spherex-tex installation
 RUN mkdir spherex-tex
 
+# Disable git safe directory checks
+RUN git config --global --add safe.directory '*'
+
 # Point $TEXMFHOME to the container's texmf. This environment variable
 # exists for container runs by a user.
 ENV TEXMFHOME "/spherex-tex/texmf"


### PR DESCRIPTION
The /workspace directory that gets mounted into the container may not have the expected ownership, and this can result in errors with Git's new safe directory checks. See

https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory

This new git command in the Docker file adds a git configuration to the container that effectively disables these checks. This is fine because of the nature of the isolated container.