### PR TITLE
SP-549: Add initial version of document provenance line

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,3 +59,24 @@ jobs:
           path: test/technote/SSDC-TN-000.pdf
           retention-days: 7
           if-no-files-found: error
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: SSDC-IF-000.pdf
+          path: test/ssdc-if/SSDC-IF-000.pdf
+          retention-days: 7
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: SSDC-TR-000-va.pdf
+          path: test/ssdc-tr-va/SSDC-TR-000.pdf
+          retention-days: 7
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: SSDC-TR-000-req.pdf
+          path: test/ssdc-tr-req/SSDC-TR-000.pdf
+          retention-days: 7
+          if-no-files-found: error

--- a/texmf/tex/latex/spherex/spherex.cls
+++ b/texmf/tex/latex/spherex/spherex.cls
@@ -335,6 +335,9 @@
     \endlastfoot
 }{
 \end{longtable}
+
+(Document generated on \today\ from commit \vcsRevision\ of \vcsDate.)
+
 \end{small}
 
 \clearpage


### PR DESCRIPTION
Also corrects a problem with the test suite for the repo, in which the PDF outputs from three tests were not being uploaded as artifacts.