### PR TITLE
SP-896: Add compact-title macro for one-page documents

### DIFF
--- a/test/ssdc-tr-req/SSDC-TR-000.tex
+++ b/test/ssdc-tr-req/SSDC-TR-000.tex
@@ -14,7 +14,7 @@
 \approved{2021-01-01}{Edwin Hubble}
 
 \begin{document}
-\maketitle
+\maketitlecompact
 
 \begin{dochistory}
 \addtohist{0.1}{2020-01-01}{Initial draft.}{Galileo Galilei}

--- a/test/ssdc-tr-req/SSDC-TR-000.tex
+++ b/test/ssdc-tr-req/SSDC-TR-000.tex
@@ -3,32 +3,46 @@
 \input{meta}
 
 \spherexHandle{SSDC-TR-000}
-\title{Requirements Title}
+\title{Level 0 Data Ingest}
+\shortTitle{Requirement 1007268 Closure Memo}
 \version{1.0}
 \docDate{2021-01-01} % override the vcs date
-\ReqDoorsID[https://example.org/12345]{12345}
+\ReqDoorsID[https://example.org/1007268]{1007268}
 \IPACJiraID{SVV-999}
 
-\spherexlead[email=galileo@example.com]{Galileo Galilei}
+\ipaclead[email=galileo@example.com]{Galileo Galilei}
 
 \approved{2021-01-01}{Edwin Hubble}
 
 \begin{document}
 \maketitlecompact
 
-\begin{dochistory}
-\addtohist{0.1}{2020-01-01}{Initial draft.}{Galileo Galilei}
-\addtohist{1.0}{2021-01-01}{Initial accepted version.}{Galileo Galilei}
-\end{dochistory}
+% \begin{dochistory}
+% \addtohist{0.1}{2020-01-01}{Initial draft.}{Galileo Galilei}
+% \addtohist{1.0}{2021-01-01}{Initial accepted version.}{Galileo Galilei}
+% \end{dochistory}
 
-\section{Introduction}
+\subsection*{Requirement}
 
-Lorem ipsum. \cite{SPHEREx_SPIE}
+\begin{longtable}{|l|p{0.8\textwidth}|}
+\hline
+\textbf{DNG ID} & \textbf{Requirement} \\
+\endhead
+\hline
+\href{https://cae-tracetree-spherex.jpl.nasa.gov/vi1007268.html}{1007268} &
+REQ: L4\_SOS\_SSDC -- Level 0 Data Ingest (IPAC JIRA: \href{https://jira.ipac.caltech.edu/browse/SVV-999}{SVV-999}) \\
+ & The SSDC shall ingest, catalog, and make available for processing all Level 0 science data products obtained from the spacecraft. \\
+\hline
+\end{longtable}
+
+\subsection*{V\&V Closure Summary}
+
+Lorem ipsum. % \cite{SPHEREx_SPIE}
 
 Version: \theversion
 
 Handle: \thehandle
 
-\bibliography{spherex}
+% \bibliography{spherex}
 
 \end{document}

--- a/texmf/tex/latex/spherex/spherex.cls
+++ b/texmf/tex/latex/spherex/spherex.cls
@@ -301,8 +301,8 @@
     \vskip 0.25in
 
     \iftoggle{SpherexApproved}{
-        {\LARGE\noindent\bf Approved By: \@approvername \\ \\}
-        {\LARGE\noindent\bf Date: \@approvaldate}\\
+        {\Large\noindent\bf Approved By: \@approvername \\ \\}
+        {\Large\noindent\bf Date: \@approvaldate}\\
         \vskip 0.25in
     }{}
 

--- a/texmf/tex/latex/spherex/spherex.cls
+++ b/texmf/tex/latex/spherex/spherex.cls
@@ -311,6 +311,50 @@
     \newpage
 } % end \renewcommand{\maketitle}
 
+
+%% Compact Title for one-page documents
+\newcommand{\maketitlecompact}{
+    \begin{center}
+%        {\LARGE\@spherexHandle}
+%        \vskip 0.25in
+        {\large\bf\@title}
+        \vskip 0.25in
+        \iftoggle{SpherexPipeLevel}{
+            {\large\noindent\bf Pipeline Level: \@pipelevel \iftoggle{SpherexDiagramIndex}{\hspace{0.5in}Diagram Index: \@diagramindex}{}}
+            {\large\noindent\bf \iftoggle{SpherexDifficulty}{\vskip 0.25in Difficulty: \@difficulty}{}}
+            \vskip 0.25in
+        }{}
+        \iftoggle{SpherexInterfacePartner}{
+            {\noindent\bf Interface Partner: \@interfacepartnername }
+            \vskip 0.125in
+        }{}
+    \end{center}
+
+    \iftoggle{SpherexIpacLead}{
+      {\noindent\bf \ipac\ Lead Author: \@ipacleadname\ifdefempty{\@ipacleademail}{}{~\href{mailto:\@ipacleademail}{\@ipacleademail} \hspace{1.0in} Date: \@docDate } }
+      \vskip 0.125in
+    }{}
+    \iftoggle{SpherexSpherexLead}{
+      {\noindent\bf \spherex\ POC: \@spherexleadname\ifdefempty{\@spherexleademail}{}{~\href{mailto:\@spherexleademail}{\@spherexleademail}} }
+      \vskip 0.125in
+    }{}
+
+    \ifdefempty{\@author}{}{
+      \iftoggle{SpherexSpherexLead}{
+        \iftoggle{SpherexIpacLead}{{\noindent\bf In collaboration with:}\\ }{}
+      }{{\noindent\bf Authors:}\\}
+      \@author\\
+    }
+
+    \iftoggle{SpherexApproved}{
+        {\noindent\bf Approved By: \@approvername\ (Date: \@approvaldate)}\\
+        \vskip 0.125in
+    }{}
+
+    % no table of contents, no new page
+
+} % end \newcommand{\maketitlecompact}
+
 %% Document history
 \newenvironment{dochistory}[0]{
   \newpage


### PR DESCRIPTION
Used in Requirement Closure Memos to keep them to a single page